### PR TITLE
Improved autoselection of SimpleLDAP user import

### DIFF
--- a/simple_ldap_user/simple_ldap_user.admin.inc
+++ b/simple_ldap_user/simple_ldap_user.admin.inc
@@ -309,11 +309,18 @@ function simple_ldap_user_import($form, &$form_state) {
   }
   asort($users);
 
+  // Only selects new users
+  $drupal_users = entity_load('user');
+  $new_names = $users;
+  foreach ($drupal_users as $user) {
+      unset($new_names[strtoupper($user->name)]);
+  }
+
   $form['users'] = array(
     '#type' => 'checkboxes',
     '#title' => t('Import these users') . ' (' . count($users) . ')',
     '#options' => $users,
-    '#default_value' => array_keys($users),
+    '#default_value' => $new_names,
     '#checkall' => TRUE,
   );
 


### PR DESCRIPTION
Drupal's SimpleLDAP module is able to import users from LDAP to Drupal.  (This option appears on the "People" screen.)  It automatically selects each user.  I think it should only select new users.
